### PR TITLE
Refactor Clarity import statement for consistency

### DIFF
--- a/src/components/ui/Clarity.tsx
+++ b/src/components/ui/Clarity.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
-import { clarity } from "@microsoft/clarity";
+import clarity from "@microsoft/clarity";
 
 export default function Clarity() {
   useEffect(() => {


### PR DESCRIPTION
- Changed the import statement for the clarity module from named import to default import for improved clarity and consistency in the codebase.