### PR TITLE
fix: correct pnpm overrides location and pin Vercel install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ pnpm format
 
 El sitio se despliega en **[Vercel](https://vercel.com/)**.
 
-- Vercel detecta pnpm automáticamente a través del campo `packageManager` en `package.json` (vía Corepack), sin configuración adicional de build.
+- El comando de instalación (`pnpm install --frozen-lockfile`) está fijado en [`vercel.json`](./vercel.json), que tiene prioridad sobre cualquier configuración manual del dashboard (Settings → Build & Development Settings). Esto asegura que Vercel siempre use pnpm, sin depender de configuración fuera del repositorio.
 - Las variables de entorno de [Variables de Entorno](#variables-de-entorno) deben configurarse en el proyecto de Vercel (Settings → Environment Variables) para que el build y el runtime de producción funcionen.
 
 ## Contribución

--- a/package.json
+++ b/package.json
@@ -87,9 +87,11 @@
     "tailwindcss": "^4.1.18",
     "typescript": "5.6.3"
   },
-  "overrides": {
-    "@types/react": "19.2.17",
-    "@types/react-dom": "19.2.3"
+  "pnpm": {
+    "overrides": {
+      "@types/react": "19.2.17",
+      "@types/react-dom": "19.2.3"
+    }
   },
   "engines": {
     "node": ">=20.12.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@types/react': 19.2.17
+  '@types/react-dom': 19.2.3
+
 importers:
 
   .:
@@ -91,10 +95,10 @@ importers:
         specifier: 20.5.7
         version: 20.5.7
       '@types/react':
-        specifier: ^19.2.17
+        specifier: 19.2.17
         version: 19.2.17
       '@types/react-dom':
-        specifier: ^19.2.3
+        specifier: 19.2.3
         version: 19.2.3(@types/react@19.2.17)
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.0.0
@@ -295,7 +299,7 @@ packages:
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@date-fns/tz': ^1.2.0
-      '@types/react': ^17 || ^18 || ^19
+      '@types/react': 19.2.17
       date-fns: ^4.0.0
       react: ^17 || ^18 || ^19
       react-dom: ^17 || ^18 || ^19
@@ -310,7 +314,7 @@ packages:
   '@base-ui/utils@0.3.1':
     resolution: {integrity: sha512-gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg==}
     peerDependencies:
-      '@types/react': ^17 || ^18 || ^19
+      '@types/react': 19.2.17
       react: ^17 || ^18 || ^19
       react-dom: ^17 || ^18 || ^19
     peerDependenciesMeta:
@@ -685,7 +689,7 @@ packages:
   '@shadcn/react@0.2.1':
     resolution: {integrity: sha512-5krgi3dRMKb5jH6a+qPzVJUy/54s0kKE4Rw4LjDfLqOdVQTWKUgxWf1kW8r912I0jX/Lzxqc+pgjkjWxUIK5BQ==}
     peerDependencies:
-      '@types/react': '>=19'
+      '@types/react': 19.2.17
       react: '>=19'
     peerDependenciesMeta:
       '@types/react':
@@ -812,7 +816,7 @@ packages:
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
-      '@types/react': ^19.2.0
+      '@types/react': 19.2.17
 
   '@types/react@19.2.17':
     resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "installCommand": "pnpm install --frozen-lockfile"
+}


### PR DESCRIPTION
## Summary
- El build en Vercel falló con `npm error EOVERRIDE` porque el Install Command del dashboard estaba forzando `npm install --legacy-peer-deps` en lugar de pnpm, y ese npm sí interpretaba el campo `overrides` (mal ubicado en la raíz de `package.json`) como un conflicto con la devDependency directa de `@types/react`.
- El campo `overrides` nunca tuvo efecto real bajo pnpm: pnpm solo lee overrides desde `pnpm.overrides` en `package.json` (válido hasta pnpm 10.x; en pnpm 11+ ese campo se mueve a `pnpm-workspace.yaml`). Se corrigió la ubicación y se regeneró `pnpm-lock.yaml` para confirmar que el override ahora se aplica.
- Se agregó `vercel.json` fijando `installCommand: "pnpm install --frozen-lockfile"`. Este archivo tiene prioridad sobre la configuración manual del dashboard de Vercel, así que aunque el Install Command quede mal configurado ahí, el deploy va a usar pnpm igual.
- README actualizado para reflejar que la fuente de verdad del install command es `vercel.json`, no la detección automática.


## Test plan
- [x] `pnpm install --frozen-lockfile` corre sin errores localmente
- [x] Verificar que el próximo deploy en Vercel (Preview de este PR) instale con pnpm y no falle con EOVERRIDE
- [ ] Confirmar con Isra qué opción prefiere para `vercel.json` antes de mergear